### PR TITLE
add extra python gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.env
 /test.py
 /app.py
+__pycache__/
+dist


### PR DESCRIPTION
dist/ and __pycache\__/ shouldn't be included in the git repo, there's others as well but I don't think it's necessary for right now.

If you want to distribute artifacts you can use GitHub's actions/upload-artifact action in your workflow files